### PR TITLE
Update `easy_deploy.py` for botocore 1.4.11

### DIFF
--- a/opsworks-easy-deploy/easy_deploy.py
+++ b/opsworks-easy-deploy/easy_deploy.py
@@ -48,7 +48,7 @@ class Operation(object):
     @property
     def stack_id(self):
         if self._stack_id is None:
-            stacks = self._make_api_call('opsworks', 'DescribeStacks')['Stacks']
+            stacks = self._make_api_call('opsworks', 'describe_stacks')['Stacks']
             stack_names = [stack['Name'] for stack in stacks]
             for stack in stacks:
                 stack_id = stack['StackId']
@@ -63,7 +63,7 @@ class Operation(object):
     @property
     def layer_id(self):
         if self._layer_id is None:
-            layers = self._make_api_call('opsworks', 'DescribeLayers', stack_id=self.stack_id)['Layers']
+            layers = self._make_api_call('opsworks', 'describe_layers', StackId=self.stack_id)['Layers']
             layer_names = [each_layer['Name'] for each_layer in layers]
             for each_layer in layers:
                 layer_id = each_layer['LayerId']
@@ -76,7 +76,7 @@ class Operation(object):
         return self._layer_id
 
     def layer_at_once(self, comment, exclude_hosts=None):
-        all_instances = self._make_api_call('opsworks', 'DescribeInstances', layer_id=self.layer_id)
+        all_instances = self._make_api_call('opsworks', 'describe_instances', LayerId=self.layer_id)
 
         if exclude_hosts is None:
             exclude_hosts = []
@@ -85,7 +85,7 @@ class Operation(object):
         for each in all_instances['Instances']:
             if each['Status'] == 'online' and each['Hostname'] not in exclude_hosts:
                 deployment_instance_ids.append(each['InstanceId'])
-        self._deploy_to(instance_ids=deployment_instance_ids, name="{0} instances".format(self.layer_name), comment=comment)
+        self._deploy_to(InstanceIds=deployment_instance_ids, Name="{0} instances".format(self.layer_name), Comment=comment)
 
     def layer_rolling(self, comment):
         load_balancer_name = self._get_opsworks_elb_name()
@@ -94,7 +94,7 @@ class Operation(object):
             self.pre_deployment_hooks.append(self._remove_instance_from_elb)
             self.post_deployment_hooks.append(self._add_instance_to_elb)
 
-        all_instances = self._make_api_call('opsworks', 'DescribeInstances', layer_id=self.layer_id)
+        all_instances = self._make_api_call('opsworks', 'describe_instances', LayerId=self.layer_id)
         for each in all_instances['Instances']:
             if each['Status'] != 'online':
                 continue
@@ -103,20 +103,20 @@ class Operation(object):
             instance_id = each['InstanceId']
             ec2_instance_id = each['Ec2InstanceId']
 
-            self._deploy_to(instance_ids=[instance_id], name=hostname, comment=comment, load_balancer_name=load_balancer_name, ec2_instance_id=ec2_instance_id)
+            self._deploy_to(InstanceIds=[instance_id], Name=hostname, Comment=comment, LoadBalancerName=load_balancer_name, Ec2InstanceId=ec2_instance_id)
 
     def instances_at_once(self, host_names, comment):
-        all_instances = self._make_api_call('opsworks', 'DescribeInstances', stack_id=self.stack_id)
+        all_instances = self._make_api_call('opsworks', 'describe_instances', StackId=self.stack_id)
 
         deployment_instance_ids = []
         for each in all_instances['Instances']:
             if each['Status'] == 'online' and each['Hostname'] in host_names:
                 deployment_instance_ids.append(each['InstanceId'])
 
-        self._deploy_to(instance_ids=deployment_instance_ids, name=", ".join(host_names), comment=comment)
+        self._deploy_to(InstanceIds=deployment_instance_ids, Name=", ".join(host_names), Comment=comment)
 
     def post_elb_registration(self, hostname, load_balancer_name):
-        describe_result = self._make_api_call('elb', 'DescribeLoadBalancers', load_balancer_names=[load_balancer_name])
+        describe_result = self._make_api_call('elb', 'describe_load_balancers', LoadBalancerNames=[load_balancer_name])
         healthy_threshold = describe_result['LoadBalancerDescriptions'][0]['HealthCheck']['HealthyThreshold']
         interval = describe_result['LoadBalancerDescriptions'][0]['HealthCheck']['Interval']
 
@@ -129,7 +129,7 @@ class Operation(object):
         Get an OpsWorks ELB Name of the layer id in the stack if is associated with the layer
         :return: Elastic Load Balancer name if associated with the layer, otherwise None
         """
-        elbs = self._make_api_call('opsworks', 'DescribeElasticLoadBalancers', layer_ids=[self.layer_id])
+        elbs = self._make_api_call('opsworks', 'describe_elastic_load_balancers', LayerIds=[self.layer_id])
         if len(elbs['ElasticLoadBalancers']) > 0:
             return elbs['ElasticLoadBalancers'][0]['ElasticLoadBalancerName']
         else:
@@ -139,11 +139,11 @@ class Operation(object):
         for pre_deploy in self.pre_deployment_hooks:
             pre_deploy(**kwargs)
 
-        arguments = self._create_deployment_arguments(kwargs['instance_ids'], kwargs['comment'])
-        deployment = self._make_api_call('opsworks', 'CreateDeployment', **arguments)
+        arguments = self._create_deployment_arguments(kwargs['InstanceIds'], kwargs['Comment'])
+        deployment = self._make_api_call('opsworks', 'create_deployment', **arguments)
 
         deployment_id = deployment['DeploymentId']
-        log("Deployment {0} to {1} requested - command: {2}".format(deployment_id, kwargs['name'], self.command))
+        log("Deployment {0} to {1} requested - command: {2}".format(deployment_id, kwargs['Name'], self.command))
 
         self._poll_deployment_complete(deployment_id)
 
@@ -156,7 +156,7 @@ class Operation(object):
     def _poll_deployment_complete(self, deployment_id):
         start_time = time.time()
         while True:
-            deployment_status = self._make_api_call('opsworks', 'DescribeDeployments', deployment_ids=[deployment_id])
+            deployment_status = self._make_api_call('opsworks', 'describe_deployments', DeploymentIds=[deployment_id])
 
             for each in deployment_status['Deployments']:
                 if each['DeploymentId'] == deployment_id:
@@ -191,27 +191,27 @@ class Operation(object):
         return completed_at - started_at
 
     def _add_instance_to_elb(self, **kwargs):
-        self._make_api_call('elb', 'RegisterInstancesWithLoadBalancer',
-                            load_balancer_name=kwargs['load_balancer_name'],
-                            instances=[{'InstanceId': kwargs['ec2_instance_id']}])
+        self._make_api_call('elb', 'register_instances_with_load_balancer',
+                            LoadBalancerName=kwargs['LoadBalancerName'],
+                            Instances=[{'InstanceId': kwargs['Ec2InstanceId']}])
 
-        self.post_elb_registration(kwargs['name'], kwargs['load_balancer_name'])
+        self.post_elb_registration(kwargs['Name'], kwargs['LoadBalancerName'])
 
-        if not self._is_instance_healthy(kwargs['load_balancer_name'], kwargs['ec2_instance_id']):
-            log("Instance {0} did not come online after deploy. Aborting remaining deployment".format(kwargs['name']))
+        if not self._is_instance_healthy(kwargs['LoadBalancerName'], kwargs['Ec2InstanceId']):
+            log("Instance {0} did not come online after deploy. Aborting remaining deployment".format(kwargs['Name']))
             sys.exit(1)
 
     def _remove_instance_from_elb(self, **kwargs):
-        deregister_response = self._make_api_call('elb', 'DeregisterInstancesFromLoadBalancer',
-                                                  load_balancer_name=kwargs['load_balancer_name'],
-                                                  instances=[{'InstanceId': kwargs['ec2_instance_id']}])
-        log("Removed {0} from ELB {1}. There are still {2} instance(s) online".format(kwargs['name'], kwargs['load_balancer_name'], len(deregister_response['Instances'])))
+        deregister_response = self._make_api_call('elb', 'deregister_instances_from_load_balancer',
+                                                  LoadBalancerName=kwargs['LoadBalancerName'],
+                                                  Instances=[{'InstanceId': kwargs['Ec2InstanceId']}])
+        log("Removed {0} from ELB {1}. There are still {2} instance(s) online".format(kwargs['Name'], kwargs['LoadBalancerName'], len(deregister_response['Instances'])))
 
-        self._wait_for_elb(kwargs['load_balancer_name'])
+        self._wait_for_elb(kwargs['LoadBalancerName'])
 
     def _wait_for_elb(self, load_balancer_name):
-        elb_attributes = self._make_api_call('elb', 'DescribeLoadBalancerAttributes',
-                                             load_balancer_name=load_balancer_name)
+        elb_attributes = self._make_api_call('elb', 'describe_load_balancer_attributes',
+                                             LoadBalancerName=load_balancer_name)
         if 'ConnectionDraining' in elb_attributes['LoadBalancerAttributes']:
             connection_draining = elb_attributes['LoadBalancerAttributes']['ConnectionDraining']
             if connection_draining['Enabled']:
@@ -223,9 +223,9 @@ class Operation(object):
         time.sleep(20)
 
     def _is_instance_healthy(self, load_balancer_name, instance_id):
-        instance_health = self._make_api_call('elb', 'DescribeInstanceHealth',
-                                              load_balancer_name=load_balancer_name,
-                                              instances=[{'InstanceId': instance_id}])
+        instance_health = self._make_api_call('elb', 'describe_instance_health',
+                                              LoadBalancerName=load_balancer_name,
+                                              Instances=[{'InstanceId': instance_id}])
 
         for each in instance_health['InstanceStates']:
             if each['InstanceId'] == instance_id:
@@ -243,18 +243,11 @@ class Operation(object):
         :param service_name: AWS Service name (all lowercase)
         :param api_operation: Operation name to perform
         :param kwargs: Any additional arguments to be passed to the service call
-        :return: If an OK response returned, returns the data from the call.  Will exit(1) otherwise
+        :return: Returns the data from the call.
         """
-        service = self.session.get_service(service_name)
-        endpoint_region = self.service_endpoints.get(service_name, 'us-east-1')
-        endpoint = service.get_endpoint(endpoint_region)
-        operation = service.get_operation(api_operation)
-        response, response_data = operation.call(endpoint, **kwargs)
-        if response.ok:
-            return response_data
-
-        log("Error occurred calling {0} - {1} - Status {2} Message {3}".format(response.url, api_operation, response.status_code, response.text))
-        sys.exit(1)
+        service_endpoint = self.service_endpoints[service_name]
+        service = self.session.create_client(service_name, service_endpoint)
+        return getattr(service, api_operation)(**kwargs)
 
 
 class Update(Operation):
@@ -278,7 +271,7 @@ class Update(Operation):
         Additional buffer when performing updates
         """
         if self.allow_reboot:
-            log("Sleeping {0} seconds to allow {1} to reboot (if required)".format(self.reboot_delay, kwargs['name']))
+            log("Sleeping {0} seconds to allow {1} to reboot (if required)".format(self.reboot_delay, kwargs['Name']))
             time.sleep(self.reboot_delay)
 
     def _create_deployment_arguments(self, instance_ids, comment):
@@ -291,11 +284,11 @@ class Update(Operation):
             custom_json['dependencies']['os_release_version'] = self.amazon_linux_release
 
         return {
-            'stack_id': self.stack_id,
-            'instance_ids': instance_ids,
-            'command': {'Name': self.command},
-            'comment': comment,
-            'custom_json': json.dumps(custom_json)
+            'StackId': self.stack_id,
+            'InstanceIds': instance_ids,
+            'Command': {'Name': self.command},
+            'Comment': comment,
+            'CustomJson': json.dumps(custom_json)
         }
 
 
@@ -316,7 +309,7 @@ class Deploy(Operation):
     @property
     def application_id(self):
         if self._application_id is None:
-            applications = self._make_api_call('opsworks', 'DescribeApps', stack_id=self.stack_id)
+            applications = self._make_api_call('opsworks', 'describe_apps', StackId=self.stack_id)
             application_names = [each['Shortname'] for each in applications['Apps']]
             for each in applications['Apps']:
                 if each['Shortname'] == self.application_name:
@@ -331,11 +324,11 @@ class Deploy(Operation):
 
     def _create_deployment_arguments(self, instance_ids, comment):
         return {
-            'stack_id': self.stack_id,
-            'app_id': self.application_id,
-            'instance_ids': instance_ids,
-            'command': {'Name': self.command},
-            'comment': comment
+            'StackId': self.stack_id,
+            'AppId': self.application_id,
+            'InstanceIds': instance_ids,
+            'Command': {'Name': self.command},
+            'Comment': comment
         }
 
 

--- a/opsworks-easy-deploy/requirements.txt
+++ b/opsworks-easy-deploy/requirements.txt
@@ -1,3 +1,3 @@
 click==3.3
-botocore==0.64.0
+botocore==1.4.11
 arrow==0.4.4


### PR DESCRIPTION
Related issue: #4 

This PR updates `easy_deploy.py` to make it work with botocore 1.4.11.

The major change from 0.64.0 is the client interface.
See https://botocore.readthedocs.org/en/latest/client_upgrades.html#client-upgrades for details.
