### PR TITLE
Fix breaking changes from 0ca84901a86c9f4b042fa8a078b0d737ba510450

### DIFF
--- a/opsworks-easy-deploy/easy_deploy.py
+++ b/opsworks-easy-deploy/easy_deploy.py
@@ -390,7 +390,7 @@ def all(ctx, stack_name, layer_name, exclude_hosts, comment, timeout):
 @click.option('--stack-name', type=click.STRING, required=True, help='OpsWorks Stack name')
 @click.option('--layer-name', type=click.STRING, required=True, help='Layer to deploy application to')
 @click.option('--comment', help='Deployment message')
-@click.option('--custom-json', default=None, help='Custom Json')
+@click.option('--custom-json', default='{}', help='Custom Json')
 @click.option('--timeout', default=None, help='Deployment timeout')
 @click.pass_context
 def rolling(ctx, stack_name, layer_name, comment, custom_json, timeout):


### PR DESCRIPTION
This makes the custom_json option optional once more.

Right now, if you don't provide the `--custom-json` option you get the following error, and deploying fails:

```
Invalid type for parameter CustomJson, value: None, type: <type 'NoneType'>, valid types: <type 'basestring'>
```

This PR changes the default value so the script doesn't error when trying to json parse the current default value of `None`.